### PR TITLE
add support for single box mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,19 @@ bool | None
 </tr>
 
 <tr>
+<td align="left"><code>single_box</code></td>
+<td align="left" style="width: 25%;">
+
+```python
+bool
+```
+
+</td>
+<td align="left"><code>False</code></td>
+<td align="left">If True, at most one box can be drawn. Drawing a box when one already exists will replace it.</td>
+</tr>
+
+<tr>
 <td align="left"><code>height</code></td>
 <td align="left" style="width: 25%;">
 

--- a/backend/gradio_image_annotation/image_annotator.py
+++ b/backend/gradio_image_annotation/image_annotator.py
@@ -54,6 +54,7 @@ class image_annotator(Component):
         box_thickness: int | None = None,
         box_selected_thickness: int | None = None,
         disable_edit_boxes: bool | None = None,
+        single_box: bool = False,
         height: int | str | None = None,
         width: int | str | None = None,
         image_mode: Literal[
@@ -87,6 +88,7 @@ class image_annotator(Component):
             box_thickness: Thickness of the bounding box outline.
             box_selected_thickness: Thickness of the bounding box outline when it is selected.
             disable_edit_boxes: Disables the ability to set and edit the label and color of the boxes.
+            single_box: If True, at most one box can be drawn.
             height: The height of the displayed image, specified in pixels if a number is passed, or in CSS units if a string is passed.
             width: The width of the displayed image, specified in pixels if a number is passed, or in CSS units if a string is passed.
             image_mode: "RGB" if color, or "L" if black and white. See https://pillow.readthedocs.io/en/stable/handbook/concepts.html for other supported image modes and their meaning.
@@ -146,6 +148,7 @@ class image_annotator(Component):
         self.box_thickness = box_thickness
         self.box_selected_thickness = box_selected_thickness
         self.disable_edit_boxes = disable_edit_boxes
+        self.single_box = single_box
         if label_list:
             self.label_list = [(l, i) for i, l in enumerate(label_list)]
         else:

--- a/frontend/Index.svelte
+++ b/frontend/Index.svelte
@@ -42,6 +42,7 @@
 	export let box_thickness: number;
 	export let box_selected_thickness: number;
 	export let disable_edit_boxes: boolean;
+	export let single_box: boolean;
 	export let show_remove_button: boolean;
 
 	export let gradio: Gradio<{
@@ -117,6 +118,7 @@
 		boxThickness={box_thickness}
 		boxSelectedThickness={box_selected_thickness}
 		disableEditBoxes={disable_edit_boxes}
+		singleBox={single_box}
 		showRemoveButton={show_remove_button}
 	>
 		{#if active_source === "upload"}

--- a/frontend/shared/Canvas.svelte
+++ b/frontend/shared/Canvas.svelte
@@ -19,6 +19,7 @@
 	export let choices = [];
     export let choicesColors = [];
 	export let disableEditBoxes: boolean = false;
+	export let singleBox: boolean = false;
 	export let showRemoveButton: boolean = null;
 
 	if (showRemoveButton === null) {
@@ -149,6 +150,12 @@
 		let color;
 		if (choicesColors.length > 0) {
 			color = colorHexToRGB(choicesColors[0]);
+		} else if (singleBox) {
+			if (value.boxes.length > 0) {
+				color = value.boxes[0].color;
+			} else {
+				color = Colors[0];
+			}
 		} else {
 			color = Colors[value.boxes.length % Colors.length];
 		}
@@ -173,7 +180,11 @@
 			boxSelectedThickness
 		);
 		box.startCreating(event, rect.left, rect.top);
-		value.boxes = [box, ...value.boxes];
+		if (singleBox) {
+			value.boxes = [box];
+		} else {
+			value.boxes = [box, ...value.boxes];
+		}
 		selectBox(0);
 		draw();
 		dispatch("change");

--- a/frontend/shared/ImageAnnotator.svelte
+++ b/frontend/shared/ImageAnnotator.svelte
@@ -31,6 +31,7 @@
 	export let handleSize: number;
 	export let boxThickness: number;
 	export let disableEditBoxes: boolean;
+	export let singleBox: boolean;
 	export let showRemoveButton: boolean;
 	export let boxSelectedThickness: number;
 	export let max_file_size: number | null = null;
@@ -152,6 +153,7 @@
 					{interactive}
 					{handleSize}
 					{boxThickness}
+					{singleBox}
 					{disableEditBoxes}
 					{showRemoveButton}
 					boxSelectedThickness={boxSelectedThickness}

--- a/frontend/shared/ImageCanvas.svelte
+++ b/frontend/shared/ImageCanvas.svelte
@@ -20,6 +20,7 @@
 	export let boxSelectedThickness: number;
 	export let value: null | AnnotatedImageData;
 	export let disableEditBoxes: boolean;
+	export let singleBox: boolean;
 	export let showRemoveButton: boolean;
 
 	let resolved_src: typeof src;
@@ -63,6 +64,7 @@
 	{boxThickness}
 	{boxSelectedThickness}
 	{disableEditBoxes}
+	{singleBox}
 	{showRemoveButton}
 	imageUrl={resolved_src}
 />


### PR DESCRIPTION
In this mode, drawing a box when one already exists will replace it instead of appending it. This is useful for models that require a single box as input.