### PR TITLE
fix cursor behavior in single box mode

### DIFF
--- a/frontend/shared/Canvas.svelte
+++ b/frontend/shared/Canvas.svelte
@@ -217,7 +217,6 @@
 		box.startCreating(event, rect.left, rect.top);
 		if (singleBox) {
 			value.boxes = [box];
-			setDragMode();
 		} else {
 			value.boxes = [box, ...value.boxes];
 		}
@@ -240,8 +239,13 @@
 		if (selectedBox >= 0 && selectedBox < value.boxes.length) {
 			if (value.boxes[selectedBox].getArea() < 1) {
 				onDeleteBox();
-			} else if (!disableEditBoxes){
-				newModalVisible = true;
+			} else {
+				if (!disableEditBoxes) {
+					newModalVisible = true;
+				}
+				if (singleBox) {
+					setDragMode();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When creating a box in single box mode, the mode was switched to drag mode too early, causing the cursor to show up as a handle instead of the expected crosshair.
This PR fix it.