### PR TITLE
fix image rotate issue in gr.Examples

### DIFF
--- a/frontend/shared/Canvas.svelte
+++ b/frontend/shared/Canvas.svelte
@@ -530,6 +530,7 @@
 
 	$: {
 		value;
+		canvasWindow.orientation = value.orientation;
 		setImage();
 		parseInputBoxes();
 		resize();


### PR DESCRIPTION
fix image rotate orientation wasn't updated while clicking examples.